### PR TITLE
Make apparent that Chrome Android could work

### DIFF
--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -31,7 +31,11 @@ export default function Home() {
         <section>
           <h2>Requirements</h2>
           <ul>
-            <li>A web browser which supports WebUSB (such as Google Chrome, Microsoft Edge, Opera).</li>
+            <li>
+              A web browser which supports WebUSB (such as Google Chrome, Microsoft Edge, Opera).
+              Note that Chrome or similar browsers on Android devices with 6GB+ of RAM and an
+              extended screen timeout setting may work as well.
+            </li>
             <li>A USB-C cable to power your device outside the car.</li>
             <ul>
               <li>You can use a 5V or 12V power adapter.</li>

--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -97,7 +97,13 @@ export default function Home() {
             USB hub between your computer and the device.
           </p>
           <p>
-            Computers running macOS or Linux have fewer issues getting connected than Windows.
+            You may also want to try to use a different type of workstation type to flash with. In order from easiest to most troublesome:
+            <ul>
+              <li>Mac</li>
+              <li>Android with 6GB+ of RAM</li>
+              <li>Windows</li>
+              <li>Linux (You may need to search on how to allow WebUSB)</li>
+            </ul>
           </p>
           <h3>My device&apos;s screen is blank</h3>
           <p>


### PR DESCRIPTION
It is not commonly apparent that Chrome on Android can work too. From manually helping in Discord, Android has become one of the most successful platforms to flash comma devices with.

Users may not have a Mac and their Windows machine may be funky. They might try to dual boot Linux but that comes with its own bag of hurt for AGNOS flasher and even the web flasher with WebUSB functionality smashing into strict Linux permissions. Not to mention possible issues with USB 3.0 hardware out of their control.

These issues are eliminated with Android. There are no permission issues. There are no USB 3.0 issues. Its Linux even without the WebUSB stuff is enough to get the device into Fastboot. You can even flash in your car with the addition of providing a known good and stable 12V OBD-C power source.

Suitable Android devices aren't rare particularly around the openpilot demographic.

Last but not least, in addition to relief for users, the fact this can be done seems to amuse many of them too. That's an exceptionally wonderful experience and conclusion to a "bricking" problem.