### PR TITLE
refactor: download and decompress xz images

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,12 +21,12 @@
     "jssha": "^3.3.1",
     "next": "13.4.1",
     "next-plausible": "^3.10.1",
-    "pako": "2.1.0",
     "postcss": "8.4.24",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "tailwindcss": "3.3.2",
-    "web-vitals": "^3.4.0"
+    "web-vitals": "^3.4.0",
+    "xzwasm": "^0.1.2"
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.9",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "react-dom": "18.2.0",
     "tailwindcss": "3.3.2",
     "web-vitals": "^3.4.0",
-    "xzwasm": "^0.1.2"
+    "xz-decompress": "^0.2.1"
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
@@ -29,9 +29,6 @@ dependencies:
   next-plausible:
     specifier: ^3.10.1
     version: 3.10.1(next@13.4.1)(react-dom@18.2.0)(react@18.2.0)
-  pako:
-    specifier: 2.1.0
-    version: 2.1.0
   postcss:
     specifier: 8.4.24
     version: 8.4.24
@@ -47,6 +44,9 @@ dependencies:
   web-vitals:
     specifier: ^3.4.0
     version: 3.4.0
+  xzwasm:
+    specifier: ^0.1.2
+    version: 0.1.2
 
 devDependencies:
   '@tailwindcss/typography':
@@ -3997,6 +3997,10 @@ packages:
   /xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
     dev: true
+
+  /xzwasm@0.1.2:
+    resolution: {integrity: sha512-AhkIQcyCRTKQAlI+ENhQBB52AUZF7puNmNleawbpyGAzEyflbMbwIKlU5yN99cgiv5XVlXt0mIeYgQrdQghdsA==}
+    dev: false
 
   /yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,9 +44,9 @@ dependencies:
   web-vitals:
     specifier: ^3.4.0
     version: 3.4.0
-  xzwasm:
-    specifier: ^0.1.2
-    version: 0.1.2
+  xz-decompress:
+    specifier: ^0.2.1
+    version: 0.2.1
 
 devDependencies:
   '@tailwindcss/typography':
@@ -3998,8 +3998,9 @@ packages:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
     dev: true
 
-  /xzwasm@0.1.2:
-    resolution: {integrity: sha512-AhkIQcyCRTKQAlI+ENhQBB52AUZF7puNmNleawbpyGAzEyflbMbwIKlU5yN99cgiv5XVlXt0mIeYgQrdQghdsA==}
+  /xz-decompress@0.2.1:
+    resolution: {integrity: sha512-vgpc2zPchALa6D2lc+IFRrcAB3L4I40KmgUcPV7G70CfeMWzVdmlfDpyEczvsE435WgtH6WYYT/11Um57u7s6A==}
+    engines: {node: '>=16'}
     dev: false
 
   /yallist@3.1.1:

--- a/src/utils/manifest.js
+++ b/src/utils/manifest.js
@@ -51,17 +51,14 @@ export class Image {
     if (this.name === 'system') {
       this.checksum = json.alt.hash
       this.fileName = `${this.name}-skip-chunks-${json.hash_raw}.img`
+      this.archiveUrl = json.alt.url
     } else {
       this.checksum = json.hash
       this.fileName = `${this.name}-${json.hash_raw}.img`
-    }
+      this.archiveUrl = json.url
+    } 
 
-    let baseUrl = json.url.split('/')
-    baseUrl.pop()
-    baseUrl = baseUrl.join('/')
-
-    this.archiveFileName = this.fileName + '.gz'
-    this.archiveUrl = `${baseUrl}/${this.archiveFileName}`
+    this.archiveFileName = this.archiveUrl.split('/').pop();
   }
 }
 

--- a/src/utils/manifest.js
+++ b/src/utils/manifest.js
@@ -45,17 +45,18 @@ export class Image {
 
   constructor(json) {
     this.name = json.name
-    this.size = json.size
     this.sparse = json.sparse
 
     if (this.name === 'system') {
       this.checksum = json.alt.hash
       this.fileName = `${this.name}-skip-chunks-${json.hash_raw}.img`
       this.archiveUrl = json.alt.url
+      this.size = json.alt.size
     } else {
       this.checksum = json.hash
       this.fileName = `${this.name}-${json.hash_raw}.img`
       this.archiveUrl = json.url
+      this.size = json.size
     } 
 
     this.archiveFileName = this.archiveUrl.split('/').pop()

--- a/src/utils/manifest.js
+++ b/src/utils/manifest.js
@@ -58,7 +58,7 @@ export class Image {
       this.archiveUrl = json.url
     } 
 
-    this.archiveFileName = this.archiveUrl.split('/').pop();
+    this.archiveFileName = this.archiveUrl.split('/').pop()
   }
 }
 

--- a/src/workers/image.worker.js
+++ b/src/workers/image.worker.js
@@ -1,7 +1,7 @@
 import * as Comlink from 'comlink'
 
 import jsSHA from 'jssha'
-import { XzReadableStream } from 'xzwasm';
+import { XzReadableStream } from 'xzwasm'
 
 import { Image } from '@/utils/manifest'
 
@@ -131,7 +131,7 @@ const imageWorker = {
     try {
       const reader = (new Response(
         new XzReadableStream(archiveFile.stream())
-      )).getReader()
+      )).body.getReader()
       
       await readChunks(reader, archiveFile.size, {
         onChunk: (chunk) => {

--- a/src/workers/image.worker.js
+++ b/src/workers/image.worker.js
@@ -108,7 +108,7 @@ const imageWorker = {
    * @returns {Promise<void>}
    */
   async unpackImage(image, onProgress = undefined) {
-    const { archiveFileName, checksum: expectedChecksum, fileName } = image
+    const { archiveFileName, checksum: expectedChecksum, fileName, size: imageSize } = image
 
     let archiveFile
     try {
@@ -129,11 +129,9 @@ const imageWorker = {
     const shaObj = new jsSHA('SHA-256', 'UINT8ARRAY')
     let complete
     try {
-      const reader = (new Response(
-        new XzReadableStream(archiveFile.stream())
-      )).body.getReader()
+      const reader = (new XzReadableStream(archiveFile.stream())).getReader()
       
-      await readChunks(reader, archiveFile.size, {
+      await readChunks(reader, imageSize, {
         onChunk: (chunk) => {
           writable.write(chunk)
           shaObj.update(chunk)

--- a/src/workers/image.worker.js
+++ b/src/workers/image.worker.js
@@ -1,7 +1,7 @@
 import * as Comlink from 'comlink'
 
 import jsSHA from 'jssha'
-import { XzReadableStream } from 'xzwasm'
+import { XzReadableStream } from 'xz-decompress';
 
 import { Image } from '@/utils/manifest'
 


### PR DESCRIPTION
For #5

The manifest tests pass and the worker intializes on page load without error, but didn't test whether flashes actually go through.

Wasn't sure if the issue also meant to combine the download and unpacking steps, but that would be possible.
