### PR TITLE
Fix manifest tests

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 9
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v1

--- a/src/config.js
+++ b/src/config.js
@@ -1,7 +1,7 @@
 const config = {
   manifests: {
     release: 'https://raw.githubusercontent.com/commaai/openpilot/release3/system/hardware/tici/agnos.json',
-    // master: 'https://raw.githubusercontent.com/commaai/openpilot/master/system/hardware/tici/agnos.json',
+    master: 'https://raw.githubusercontent.com/commaai/openpilot/master/system/hardware/tici/agnos.json',
   },
 }
 

--- a/src/utils/manifest.test.js
+++ b/src/utils/manifest.test.js
@@ -14,6 +14,7 @@ async function getImageWorker() {
     imageWorker.init()
   })
 
+  vi.resetModules() // this makes the import be reevaluated on each call
   await import('./../workers/image.worker')
 
   return imageWorker
@@ -21,24 +22,6 @@ async function getImageWorker() {
 
 for (const [branch, manifestUrl] of Object.entries(config.manifests)) {
   describe(`${branch} manifest`, async () => {
-    const imageWorkerFileHandler = {
-      getFile: vi.fn(),
-      createWritable: vi.fn().mockImplementation(() => ({
-        write: vi.fn(),
-        close: vi.fn(),
-      })),
-    }
-
-    globalThis.navigator = {
-      storage: {
-        getDirectory: () => ({
-          getFileHandle: () => imageWorkerFileHandler,
-        })
-      }
-    }
-
-    const imageWorker = await getImageWorker()
-
     const images = await getManifest(manifestUrl)
 
     // Check all images are present
@@ -60,12 +43,30 @@ for (const [branch, manifestUrl] of Object.entries(config.manifests)) {
         }
 
         test('image and checksum', async () => {
+          const imageWorkerFileHandler = {
+            getFile: vi.fn(),
+            createWritable: vi.fn().mockImplementation(() => ({
+              write: vi.fn(),
+              close: vi.fn(),
+            })),
+          }
+
+          globalThis.navigator = {
+            storage: {
+              getDirectory: () => ({
+                getFileHandle: () => imageWorkerFileHandler,
+              })
+            }
+          }
+
           imageWorkerFileHandler.getFile.mockImplementation(async () => {
             const response = await fetch(image.archiveUrl)
             expect(response.ok, 'to be uploaded').toBe(true)
 
             return response.blob()
           })
+
+          const imageWorker = await getImageWorker()
 
           await imageWorker.unpackImage(image)
         }, 8 * 60 * 1000)


### PR DESCRIPTION
If both manifests (or multiple manifests) are in config.manifests, then the manifest test fails.