### PR TITLE
fix(blob): revert previous change, change log level to debug

### DIFF
--- a/src/utils/blob.js
+++ b/src/utils/blob.js
@@ -2,7 +2,6 @@ export async function download(url) {
   const response = await fetch(url, { mode: 'cors' })
   const reader = response.body.getReader()
   const contentLength = +response.headers.get('Content-Length')
-  const contentEncoding = response.headers.get('Content-Encoding')
   console.debug('[blob] Downloading', url, contentLength)
 
   const chunks = []
@@ -14,7 +13,7 @@ export async function download(url) {
 
   const blob = new Blob(chunks)
   console.debug('[blob] Downloaded', url, blob.size)
-  if (!contentEncoding && blob.size !== contentLength) console.warn('[blob] Download size mismatch', {
+  if (blob.size !== contentLength) console.warn('[blob] Download size mismatch', {
     url,
     expected: contentLength,
     actual: blob.size,

--- a/src/utils/blob.js
+++ b/src/utils/blob.js
@@ -13,7 +13,7 @@ export async function download(url) {
 
   const blob = new Blob(chunks)
   console.debug('[blob] Downloaded', url, blob.size)
-  if (blob.size !== contentLength) console.warn('[blob] Download size mismatch', {
+  if (blob.size !== contentLength) console.debug('[blob] Download size mismatch', {
     url,
     expected: contentLength,
     actual: blob.size,


### PR DESCRIPTION
Reverts #78. It seems as though the value of `Content-Encoding` header is not passed to the `fetch` caller.

- This reverts commit a32b8fd.
- Change the console log level to debug so that it is not shown as a warning