### PR TITLE
remove sparse image tests

### DIFF
--- a/src/utils/manifest.js
+++ b/src/utils/manifest.js
@@ -55,10 +55,6 @@ export class Image {
 
     this.fileName = `${this.name}-${json.hash_raw}.img`
     if (this.name === 'system' && json.alt) {
-      if (this.sparse) {
-        // before AGNOS 11 - skip-chunks image
-        this.fileName = `${this.name}-skip-chunks-${json.hash_raw}.img`
-      }
       this.checksum = json.alt.hash
       this.archiveUrl = json.alt.url
       this.size = json.alt.size

--- a/src/utils/manifest.test.js
+++ b/src/utils/manifest.test.js
@@ -32,11 +32,13 @@ for (const [branch, manifestUrl] of Object.entries(config.manifests)) {
         test('xz archive', () => {
           expect(image.fileName, 'file to be uncompressed').not.toContain('.xz')
           if (image.name === 'system') {
-            expect(image.compressed).toBe(false)
             if (image.compressed) {
               expect(image.fileName, 'not to equal archive name').not.toEqual(image.archiveFileName)
               expect(image.archiveFileName, 'archive to be in xz format').toContain('.xz')
               expect(image.archiveUrl, 'archive url to be in xz format').toContain('.xz')
+            } else {
+              expect(image.fileName, 'to equal archive name').toEqual(image.archiveFileName)
+              expect(image.archiveUrl, 'archive url to not be in xz format').not.toContain('.xz')
             }
           } else {
             expect(image.compressed, 'image to be compressed').toBe(true)

--- a/src/utils/manifest.test.js
+++ b/src/utils/manifest.test.js
@@ -32,18 +32,7 @@ for (const [branch, manifestUrl] of Object.entries(config.manifests)) {
         test('xz archive', () => {
           expect(image.fileName, 'file to be uncompressed').not.toContain('.xz')
           if (image.name === 'system') {
-            const fileNameSkipChunks = image.fileName.includes('-skip-chunks-');
-            const archiveUrlSkipChunks = image.archiveUrl.includes('-skip-chunks-');
-            expect(fileNameSkipChunks, 'file name and archive url to match').toBe(archiveUrlSkipChunks);
-
-            if (fileNameSkipChunks || archiveUrlSkipChunks) {
-              // pre AGNOS 11 assumption
-              expect(image.sparse, 'system image to be sparse').toBe(true)
-            } else {
-              // post AGNOS 11 assumption
-              expect(image.sparse, 'system image to not be sparse').toBe(false)
-            }
-
+            expect(image.compressed).toBe(false)
             if (image.compressed) {
               expect(image.fileName, 'not to equal archive name').not.toEqual(image.archiveFileName)
               expect(image.archiveFileName, 'archive to be in xz format').toContain('.xz')


### PR DESCRIPTION
I'm not sure how useful these tests are other than to check whether the manifest has "skip-chunks" in the archive url

This is failing on the agnos 11.7 manifest