### PR TITLE
manifest: don't use alt image

### DIFF
--- a/src/utils/manifest.js
+++ b/src/utils/manifest.js
@@ -11,12 +11,12 @@ export class ManifestImage {
   name
 
   /**
-   * SHA-256 checksum of the image, encoded as a hex string
+   * SHA-256 checksum of the unpacked image, encoded as a hex string
    * @type {string}
    */
   checksum
   /**
-   * Size of the unpacked image in bytes
+   * Size of the unpacked and unsparsified image in bytes
    * @type {number}
    */
   size
@@ -54,15 +54,9 @@ export class ManifestImage {
     this.sparse = json.sparse
 
     this.fileName = `${this.name}-${json.hash_raw}.img`
-    if (this.name === 'system' && json.alt) {
-      this.checksum = json.alt.hash
-      this.archiveUrl = json.alt.url
-      this.size = json.alt.size
-    } else {
-      this.checksum = json.hash
-      this.archiveUrl = json.url
-      this.size = json.size
-    }
+    this.checksum = json.hash
+    this.archiveUrl = json.url
+    this.size = json.size
 
     this.archiveFileName = this.archiveUrl.split('/').pop()
     this.compressed = this.archiveFileName.endsWith('.xz')


### PR DESCRIPTION
The alt image in the latest manifest is uncompressed which was intended to speed things up with squashfs, but since the download speed from Azure seems quite slow it doesn't offer any improvement over the xz compressed image.

This also fixes https://github.com/commaai/flash/issues/115 as the `alt.hash` is actually a `hash_raw` and not a SHA-256 checksum of the image file itself.

- [x] Tested working with comma three, configured for `master` manifest