### PR TITLE
fix: pass programmer as buffer to qdl.js to upload

### DIFF
--- a/src/app/Flash.jsx
+++ b/src/app/Flash.jsx
@@ -188,18 +188,22 @@ export default function Flash() {
   useEffect(() => {
     if (!imageWorker.current) return
 
-    // Create QDL manager with callbacks that update React state
-    qdlManager.current = new QdlManager(config.manifests.release, config.loader.url, {
-      onStepChange: setStep,
-      onMessageChange: setMessage,
-      onProgressChange: setProgress,
-      onErrorChange: setError,
-      onConnectionChange: setConnected,
-      onSerialChange: setSerial
-    })
+    fetch(config.loader.url)
+      .then((res) => res.arrayBuffer())
+      .then((programmer) => {
+        // Create QDL manager with callbacks that update React state
+        qdlManager.current = new QdlManager(config.manifests.release, programmer, {
+          onStepChange: setStep,
+          onMessageChange: setMessage,
+          onProgressChange: setProgress,
+          onErrorChange: setError,
+          onConnectionChange: setConnected,
+          onSerialChange: setSerial
+        })
 
-    // Initialize the manager
-    qdlManager.current.initialize(imageWorker.current)
+        // Initialize the manager
+        qdlManager.current.initialize(imageWorker.current)
+      });
   }, [config, imageWorker.current])
 
   // Handle user clicking the start button

--- a/src/utils/qdl.js
+++ b/src/utils/qdl.js
@@ -74,13 +74,13 @@ function isRecognizedDevice(slotCount, partitions) {
 export class QdlManager {
   /**
    * @param {string} manifestUrl
-   * @param {string} programmerUrl
+   * @param {ArrayBuffer} programmer
    * @param {QdlManagerCallbacks} callbacks
    */
-  constructor(manifestUrl, programmerUrl, callbacks = {}) {
+  constructor(manifestUrl, programmer, callbacks = {}) {
     this.manifestUrl = manifestUrl
     this.callbacks = callbacks
-    this.qdl = new qdlDevice(programmerUrl)
+    this.qdl = new qdlDevice(programmer)
     this.imageWorker = null
     /** @type {ManifestImage[]|null} */
     this.manifest = null


### PR DESCRIPTION
I made a mistake testing the changes in 6bf7ef362a97772c3d72eb9821e5933799402cb2

By running the `qdl.js` CLI I had already uploaded the programmer to the device, so Flash didn't need to and functioned normally. But for every other user, when they went to flash.comma.ai the programmer wasn't uploaded.