### PR TITLE
chore: throw error object

### DIFF
--- a/src/utils/manager.js
+++ b/src/utils/manager.js
@@ -37,7 +37,7 @@ export function checkCompatibleDevice(storageInfo) {
   // Should be the same for all comma 3/3X
   if (storageInfo.block_size !== 4096 || storageInfo.page_size !== 4096 ||
     storageInfo.num_physical !== 6 || storageInfo.mem_type !== 'UFS') {
-    throw 'UFS chip parameters mismatch'
+    throw new Error('UFS chip parameters mismatch')
   }
 
   // comma three
@@ -63,7 +63,7 @@ export function checkCompatibleDevice(storageInfo) {
     return 'userdata_90'
   }
 
-  throw 'Could not identify UFS chip'
+  throw new Error('Could not identify UFS chip')
 }
 
 /**
@@ -189,7 +189,7 @@ export class FlashManager {
       try {
         this.manifest = await getManifest(this.manifestUrl)
         if (this.manifest.length === 0) {
-          throw 'Manifest is empty'
+          throw new Error('Manifest is empty')
         }
       } catch (err) {
         console.error('[Flash] Failed to fetch manifest')
@@ -276,7 +276,7 @@ export class FlashManager {
 
         // Recreate main and backup GPT for this LUN
         if (!await this.device.repairGpt(image.gpt.lun, blob)) {
-          throw `Repairing LUN ${image.gpt.lun} failed`
+          throw new Error(`Repairing LUN ${image.gpt.lun} failed`)
         }
         onRepair(1.0)
       }
@@ -315,7 +315,7 @@ export class FlashManager {
         if (lun === persistLun) preserve.push('persist')
         console.info(`[Flash] Erasing LUN ${lun} while preserving ${preserve.map((part) => `"${part}"`).join(', ')} partitions`)
         if (!await this.device.eraseLun(lun, preserve)) {
-          throw `Erasing LUN ${lun} failed`
+          throw new Error(`Erasing LUN ${lun} failed`)
         }
       }
     } catch (err) {
@@ -357,7 +357,7 @@ export class FlashManager {
 
           this.#setMessage(`Flashing ${partitionName}`)
           if (!await this.device.flashBlob(partitionName, blob, (progress) => onSlotProgress(progress / image.size))) {
-            throw `Flashing partition "${partitionName}" failed`
+            throw new Error(`Flashing partition "${partitionName}" failed`)
           }
           onSlotProgress(1.0)
         }

--- a/src/workers/image.worker.js
+++ b/src/workers/image.worker.js
@@ -49,7 +49,7 @@ const imageWorker = {
       const fileHandle = await root.getFileHandle(fileName, { create: true })
       writable = await fileHandle.createWritable()
     } catch (e) {
-      throw new Error(`Error opening file handle: ${e}`)
+      throw new Error(`Error opening file handle: ${e}`, { cause: e })
     }
 
     console.debug(`[ImageWorker] Downloading ${image.name} from ${archiveUrl}`)
@@ -75,7 +75,7 @@ const imageWorker = {
       await stream.pipeTo(writable)
       onProgress?.(1)
     } catch (e) {
-      throw new Error(`Error unpacking archive: ${e}`)
+      throw new Error(`Error unpacking archive: ${e}`, { cause: e })
     }
   },
 
@@ -92,7 +92,7 @@ const imageWorker = {
     try {
       fileHandle = await root.getFileHandle(fileName, { create: false })
     } catch (e) {
-      throw new Error(`Error getting file handle: ${e}`)
+      throw new Error(`Error getting file handle: ${e}`, { cause: e })
     }
 
     return fileHandle.getFile()

--- a/src/workers/image.worker.js
+++ b/src/workers/image.worker.js
@@ -29,7 +29,7 @@ const imageWorker = {
     const estimate = await navigator.storage.estimate()
     const quotaMB = (estimate.quota || 0) / (1024 ** 2)
     if (quotaMB < MIN_QUOTA_MB) {
-      throw `Not enough storage: ${quotaMB.toFixed(0)}MB free, need ${MIN_QUOTA_MB.toFixed(0)}MB`
+      throw new Error(`Not enough storage: ${quotaMB.toFixed(0)}MB free, need ${MIN_QUOTA_MB.toFixed(0)}MB`)
     }
   },
 
@@ -49,13 +49,13 @@ const imageWorker = {
       const fileHandle = await root.getFileHandle(fileName, { create: true })
       writable = await fileHandle.createWritable()
     } catch (e) {
-      throw `Error opening file handle: ${e}`
+      throw new Error(`Error opening file handle: ${e}`)
     }
 
     console.debug(`[ImageWorker] Downloading ${image.name} from ${archiveUrl}`)
     const response = await fetch(archiveUrl, { mode: 'cors' })
     if (!response.ok) {
-      throw `Fetch failed: ${response.status} ${response.statusText}`
+      throw new Error(`Fetch failed: ${response.status} ${response.statusText}`)
     }
 
     const contentLength = +response.headers.get('Content-Length')
@@ -75,7 +75,7 @@ const imageWorker = {
       await stream.pipeTo(writable)
       onProgress?.(1)
     } catch (e) {
-      throw `Error unpacking archive: ${e}`
+      throw new Error(`Error unpacking archive: ${e}`)
     }
   },
 
@@ -92,7 +92,7 @@ const imageWorker = {
     try {
       fileHandle = await root.getFileHandle(fileName, { create: false })
     } catch (e) {
-      throw `Error getting file handle: ${e}`
+      throw new Error(`Error getting file handle: ${e}`)
     }
 
     return fileHandle.getFile()


### PR DESCRIPTION
It's best practice to throw `Error` objects - will include stacktrace and more details could be attached