### PR TITLE
fix: beforeUnload listener step range

### DIFF
--- a/src/app/Flash.jsx
+++ b/src/app/Flash.jsx
@@ -239,7 +239,7 @@ export default function Flash() {
   }
 
   // warn the user if they try to leave the page while flashing
-  if (step >= StepCode.FLASH_GPT && step <= StepCode.FLASH_SYSTEM) {
+  if (step >= StepCode.REPAIR_PARTITION_TABLES && step <= StepCode.FINALIZING) {
     window.addEventListener("beforeunload", beforeUnloadListener, { capture: true })
   } else {
     window.removeEventListener("beforeunload", beforeUnloadListener, { capture: true })


### PR DESCRIPTION
The code uses a non-existent step value `FLASH_GPT` when determining when to show the "unsaved changes" warning dialog. This fix corrects the range to use the proper step enum values.