### PR TITLE
fix: handle errors encountered during init

### DIFF
--- a/src/app/Flash.jsx
+++ b/src/app/Flash.jsx
@@ -209,8 +209,12 @@ export default function Flash() {
         })
 
         // Initialize the manager
-        qdlManager.current.initialize(imageManager.current)
-      });
+        return qdlManager.current.initialize(imageManager.current)
+      })
+      .catch((err) => {
+        console.error('Error initializing QDL manager:', err)
+        setError(ErrorCode.UNKNOWN)
+      })
   }, [config, imageManager.current])
 
   // Handle user clicking the start button


### PR DESCRIPTION
The initial fetch for the loader and subsequent initialization don't properly handle errors, which could result in silent failures. This fix adds proper error handling to surface these failutes to the user.