### PR TITLE
Choose manifest from URL param

### DIFF
--- a/src/app/Flash.jsx
+++ b/src/app/Flash.jsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 
 import { FlashManager, StepCode, ErrorCode } from '../utils/manager'
 import { useImageManager } from '../utils/image'
+import { getManifestUrl } from '../utils/manifest'
 import { isLinux } from '../utils/platform'
 import config from '../config'
 
@@ -188,8 +189,10 @@ export default function Flash() {
     fetch(config.loader.url)
       .then((res) => res.arrayBuffer())
       .then((programmer) => {
+        const manifestUrl = getManifestUrl(config.manifests, 'release')
+
         // Create QDL manager with callbacks that update React state
-        qdlManager.current = new FlashManager(config.manifests.release, programmer, {
+        qdlManager.current = new FlashManager(manifestUrl, programmer, {
           onStepChange: setStep,
           onMessageChange: setMessage,
           onProgressChange: setProgress,

--- a/src/utils/manifest.js
+++ b/src/utils/manifest.js
@@ -84,3 +84,16 @@ export function getManifest(url) {
     .then((response) => response.text())
     .then((text) => JSON.parse(text).map((image) => new ManifestImage(image)))
 }
+
+/**
+ * @param {Record<string, string>} manifests
+ * @param {string} defaultKey
+ * @returns {string}
+ */
+export function getManifestUrl(manifests, defaultKey) {
+  const params = new URLSearchParams(window.location.search)
+  const manifest = params.get('manifest')
+  if (!manifest) return manifests[defaultKey]
+  if (manifests[manifest]) return manifests[manifest]
+  return manifest
+}


### PR DESCRIPTION
Allow overriding the manifest used with a URL param, e.g.

`https://flash.comma.ai/?manifest=https://gitlab.com/commaai/ci-artifacts/-/raw/agnos-builder/pr-999/all-partitions.json`

(note: you need to reload the page if you change the URL param)