### PR TITLE
UI: Adjust icon links

### DIFF
--- a/src/app/index.jsx
+++ b/src/app/index.jsx
@@ -32,13 +32,13 @@ export default function App() {
       <Flash />
       <div className="absolute bottom-4 right-4 flex items-center gap-6">
         <a href="https://comma.ai" target="_blank" rel="noopener noreferrer" title="comma.ai" className="text-gray-400 hover:text-[#51ff00] transition-colors">
-          <CommaIcon className="w-12 h-12" />
+          <CommaIcon className="w-9 h-9" />
         </a>
         <a href="https://discord.comma.ai" target="_blank" rel="noopener noreferrer" title="Discord" className="text-gray-400 hover:text-[#51ff00] transition-colors">
-          <DiscordIcon className="w-12 h-12" />
+          <DiscordIcon className="w-9 h-9" />
         </a>
         <a href="https://github.com/commaai/flash" target="_blank" rel="noopener noreferrer" title="GitHub" className="text-gray-400 hover:text-[#51ff00] transition-colors">
-          <GitHubIcon className="w-12 h-12" />
+          <GitHubIcon className="w-9 h-9" />
         </a>
       </div>
       <div className="absolute bottom-4 left-4 text-sm text-gray-500">


### PR DESCRIPTION
Even though site is not supposed to be used on mobile, users are still able to have multiple windows open on their desktop which can create the UI bug if window width is small enough, or if user is utilizing browser zoom

<p align="center">
  <img
    src="https://github.com/user-attachments/assets/4943aa20-d622-4fcd-b288-3bf6eb556378"
    alt="icons-clashing"
    width="400"
  />
</p>


- Brought link icons to the bottom right since it conflicts less with other UI during window resize
- Made icons smaller so they are less distracting and less likely to hit other UI on screen resize
- When viewing video below, the Github video playback UI can cover up the bottom of video, move your mouse out of the video screen to see the bottom of vid to see the changed UI


# UI Compare

https://github.com/user-attachments/assets/015b79fc-a51b-4edb-a9a0-970beb08302b


